### PR TITLE
man3: add a function's indicators

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,4 +21,6 @@ jobs:
 
       - run: sudo make install
 
+      - run: sudo makewhatis
+
       - run: make check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Function's indicators.
+
 ### Changed
 
 ### Fixed

--- a/man3/luaL_addchar.3
+++ b/man3/luaL_addchar.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_addchar
-.Nd adds the character to the buffer
+.Nd adds the character to the buffer, function indicator
+.Bq -0, +0, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_addlstring.3
+++ b/man3/luaL_addlstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_addlstring
-.Nd adds the string to the buffer
+.Nd adds the string to the buffer, function indicator
+.Bq -0, +0, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_addsize.3
+++ b/man3/luaL_addsize.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_addsize
-.Nd adds to the buffer a string
+.Nd adds to the buffer a string, function indicator
+.Bq -0, +0, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_addstring.3
+++ b/man3/luaL_addstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_addstring
-.Nd adds the zero-terminated string to the buffer
+.Nd adds the zero-terminated string to the buffer, function indicator
+.Bq -0, +0, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_addvalue.3
+++ b/man3/luaL_addvalue.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_addvalue
-.Nd adds the value at the top of the stack to the buffer
+.Nd adds the value at the top of the stack to the buffer, function indicator
+.Bq -1, +0, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_argcheck.3
+++ b/man3/luaL_argcheck.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_argcheck
-.Nd checks whether cond is true
+.Nd checks whether cond is true, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_argerror.3
+++ b/man3/luaL_argerror.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_argerror
-.Nd raises an error with the message
+.Nd raises an error with the message, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_buffinit.3
+++ b/man3/luaL_buffinit.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_buffinit
-.Nd initializes a buffer
+.Nd initializes a buffer, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_callmeta.3
+++ b/man3/luaL_callmeta.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm luaL_callmeta
-.Nd calls a metamethod
+.Nd calls a metamethod, function indicator
+.Bo -0, + Pq 0|1 ,
+e
+.Bc
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_checkany.3
+++ b/man3/luaL_checkany.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checkany
-.Nd checks whether the function has an argument of any type
+.Nd checks whether the function has an argument of any type, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_checkint.3
+++ b/man3/luaL_checkint.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checkint
-.Nd checks whether the function argument is a number
+.Nd checks whether the function argument is a number, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_checkinteger.3
+++ b/man3/luaL_checkinteger.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checkinteger
-.Nd checks whether the function argument is a number
+.Nd checks whether the function argument is a number, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft lua_Integer

--- a/man3/luaL_checklong.3
+++ b/man3/luaL_checklong.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checklong
-.Nd checks whether the function argument is a number
+.Nd checks whether the function argument is a number, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft long

--- a/man3/luaL_checklstring.3
+++ b/man3/luaL_checklstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checklstring
-.Nd checks whether the function argument is a string
+.Nd checks whether the function argument is a string, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft const char *

--- a/man3/luaL_checknumber.3
+++ b/man3/luaL_checknumber.3
@@ -4,7 +4,8 @@
 .Sh NAME
 .Nm luaL_checknumber
 .Nd checks whether the function argument narg is a number and returns this
-number
+number, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft lua_Number

--- a/man3/luaL_checkoption.3
+++ b/man3/luaL_checkoption.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checkoption
-.Nd checks whether the function argument is a string
+.Nd checks whether the function argument is a string, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_checkstack.3
+++ b/man3/luaL_checkstack.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checkstack
-.Nd grows the stack size to specified size of elements
+.Nd grows the stack size to specified size of elements, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_checkstring.3
+++ b/man3/luaL_checkstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checkstring
-.Nd checks whether the function argument is a string and returns this string
+.Nd checks whether the function argument is a string and returns this string, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft const char *

--- a/man3/luaL_checktype.3
+++ b/man3/luaL_checktype.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checktype
-.Nd checks whether the function argument has a certain type
+.Nd checks whether the function argument has a certain type, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_checkudata.3
+++ b/man3/luaL_checkudata.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_checkudata
-.Nd checks whether the function argument is a userdata of a certain type
+.Nd checks whether the function argument is a userdata of a certain type, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void *

--- a/man3/luaL_dofile.3
+++ b/man3/luaL_dofile.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_dofile
-.Nd loads and runs the given file
+.Nd loads and runs the given file, function indicator
+.Bq -0, +?, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_dostring.3
+++ b/man3/luaL_dostring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_dostring
-.Nd loads and runs the given string
+.Nd loads and runs the given string, function indicator
+.Bq -0, +?, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_error.3
+++ b/man3/luaL_error.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_error
-.Nd raises an error
+.Nd raises an error, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_getmetafield.3
+++ b/man3/luaL_getmetafield.3
@@ -4,7 +4,10 @@
 .Sh NAME
 .Nm luaL_getmetafield
 .Nd pushes onto the stack the field from the metatable of the object at the
-specified index
+specified index, function indicator
+.Bo -0, + Pq 0|1 ,
+m
+.Bc
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_getmetatable.3
+++ b/man3/luaL_getmetatable.3
@@ -3,7 +3,9 @@
 .Os
 .Sh NAME
 .Nm luaL_getmetatable
-.Nd pushes onto the stack the metatable associated with name in the registry
+.Nd pushes onto the stack the metatable associated with name in the registry,
+function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_gsub.3
+++ b/man3/luaL_gsub.3
@@ -4,7 +4,8 @@
 .Sh NAME
 .Nm luaL_gsub
 .Nd creates a copy of string A by replacing any occurrence of the string B with
-the string C
+the string C, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft const char *

--- a/man3/luaL_loadbuffer.3
+++ b/man3/luaL_loadbuffer.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_loadbuffer
-.Nd loads a buffer as a Lua chunk
+.Nd loads a buffer as a Lua chunk, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_loadfile.3
+++ b/man3/luaL_loadfile.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_loadfile
-.Nd loads a file as a Lua chunk
+.Nd loads a file as a Lua chunk, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_loadstring.3
+++ b/man3/luaL_loadstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_loadstring
-.Nd loads a string as a Lua chunk
+.Nd loads a string as a Lua chunk, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_newmetatable.3
+++ b/man3/luaL_newmetatable.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_newmetatable
-.Nd creates a new table to be used as a metatable for userdata
+.Nd creates a new table to be used as a metatable for userdata, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_newstate.3
+++ b/man3/luaL_newstate.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_newstate
-.Nd creates a new Lua state
+.Nd creates a new Lua state, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft lua_State *

--- a/man3/luaL_openlibs.3
+++ b/man3/luaL_openlibs.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_openlibs
-.Nd opens all standard Lua libraries into the given state
+.Nd opens all standard Lua libraries into the given state, function indicator
+.Bq -0, +0, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_optint.3
+++ b/man3/luaL_optint.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_optint
-.Nd casts a number to an int
+.Nd casts a number to an int, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_optinteger.3
+++ b/man3/luaL_optinteger.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_optinteger
-.Nd casts a number to a lua_Integer
+.Nd casts a number to a lua_Integer, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft lua_Integer

--- a/man3/luaL_optlong.3
+++ b/man3/luaL_optlong.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_optlong
-.Nd casts a number to a long
+.Nd casts a number to a long, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft long

--- a/man3/luaL_optlstring.3
+++ b/man3/luaL_optlstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_optlstring
-.Nd if the function argument is a string, returns this string
+.Nd if the function argument is a string, returns this string, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft const char *

--- a/man3/luaL_optnumber.3
+++ b/man3/luaL_optnumber.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_optnumber
-.Nd if the function argument is a number, returns this number
+.Nd if the function argument is a number, returns this number, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft lua_Number

--- a/man3/luaL_optstring.3
+++ b/man3/luaL_optstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_optstring
-.Nd if the function argument is a string, returns this string
+.Nd if the function argument is a string, returns this string, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft const char *

--- a/man3/luaL_prepbuffer.3
+++ b/man3/luaL_prepbuffer.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm luaL_prepbuffer
-.Nd prepares a buffer luaL_Buffer
+.Nd prepares a buffer
+.Xr luaL_Buffer 3 ,
+function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft char *

--- a/man3/luaL_pushresult.3
+++ b/man3/luaL_pushresult.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_pushresult
-.Nd finishes the use of buffer
+.Nd finishes the use of buffer, function indicator
+.Bq -?, +1, m
 .Sh SYNOPSIS
 .In luaxlib.h
 .Ft void

--- a/man3/luaL_ref.3
+++ b/man3/luaL_ref.3
@@ -4,7 +4,8 @@
 .Sh NAME
 .Nm luaL_ref
 .Nd creates and returns a reference for the object at the top of the stack and
-pops the object
+pops the object, function indicator
+.Bq -1, +0, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_register.3
+++ b/man3/luaL_register.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm luaL_register
-.Nd opens a library
+.Nd opens a library, function indicator
+.Bo - Pq 0|1 ,
++1, m
+.Bc
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_typename.3
+++ b/man3/luaL_typename.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_typename
-.Nd returns the name of the type of the value
+.Nd returns the name of the type of the value, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft const char *

--- a/man3/luaL_typerror.3
+++ b/man3/luaL_typerror.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_typerror
-.Nd generates an error with a message
+.Nd generates an error with a message, function indicator
+.Bq -0, +0, v
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft int

--- a/man3/luaL_unref.3
+++ b/man3/luaL_unref.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm luaL_unref
-.Nd releases reference from the table
+.Nd releases reference from the table, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/luaL_where.3
+++ b/man3/luaL_where.3
@@ -4,7 +4,8 @@
 .Sh NAME
 .Nm luaL_where
 .Nd pushes onto the stack a string identifying the current position of the
-control
+control, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lauxlib.h
 .Ft void

--- a/man3/lua_atpanic.3
+++ b/man3/lua_atpanic.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_atpanic
-.Nd sets a new panic function and returns the old one
+.Nd sets a new panic function and returns the old one, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft lua_CFunction

--- a/man3/lua_call.3
+++ b/man3/lua_call.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm lua_call
-.Nd calls a function
+.Nd calls a function, function indicator
+.Bo - Pq nargs + 1 ,
++nresults, e
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_checkstack.3
+++ b/man3/lua_checkstack.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_checkstack
-.Nd ensures that there are at least extra free stack slots in the stack
+.Nd ensures that there are at least extra free stack slots in the stack, function indicator
+.Bq -0, +0, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_close.3
+++ b/man3/lua_close.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_close
-.Nd ensures that there are at least extra free stack slots in the stack
+.Nd ensures that there are at least extra free stack slots in the stack, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_concat.3
+++ b/man3/lua_concat.3
@@ -4,7 +4,8 @@
 .Sh NAME
 .Nm lua_concat
 .Nd concatenates the values at the top of the stack, pops them, and leaves the
-result at the top
+result at the top, function indicator
+.Bq -n, +1, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_cpcall.3
+++ b/man3/lua_cpcall.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm lua_cpcall
-.Nd calls the C function in protected mode
+.Nd calls the C function in protected mode, function indicator
+.Bo -0, + Pq 0|1 ,
+-
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_createtable.3
+++ b/man3/lua_createtable.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_createtable
-.Nd creates a new empty table and pushes it onto the stack
+.Nd creates a new empty table and pushes it onto the stack, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_dump.3
+++ b/man3/lua_dump.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_dump
-.Nd dumps a function as a binary chunk
+.Nd dumps a function as a binary chunk, function indicator
+.Bq -0, +0, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_equal.3
+++ b/man3/lua_equal.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_equal
-.Nd compare two values for equality
+.Nd compare two values for equality, function indicator
+.Bq -0, +0, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_error.3
+++ b/man3/lua_error.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_error
-.Nd generates a Lua error
+.Nd generates a Lua error, function indicator
+.Bq -1, +0, v
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_gc.3
+++ b/man3/lua_gc.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_gc
-.Nd controls the garbage collector
+.Nd controls the garbage collector, function indicator
+.Bq -0, +0, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_getallocf.3
+++ b/man3/lua_getallocf.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_getallocf
-.Nd returns the memory-allocation function of a given state
+.Nd returns the memory-allocation function of a given state, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft lua_Alloc

--- a/man3/lua_getfenv.3
+++ b/man3/lua_getfenv.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_getfenv
-.Nd pushes onto the stack the environment table of the value at the given index
+.Nd pushes onto the stack the environment table of the value at the given index, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_getfield.3
+++ b/man3/lua_getfield.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_getfield
-.Nd pushes onto the stack the value t[k], where t is the value at the given valid index
+.Nd pushes onto the stack the value t[k], where t is the value at the given valid index, function indicator
+.Bq -0, +1, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_getglobal.3
+++ b/man3/lua_getglobal.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_getglobal
-.Nd pushes onto the stack the value of the global name
+.Nd pushes onto the stack the value of the global name, function indicator
+.Bq -0, +1, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_gethook.3
+++ b/man3/lua_gethook.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_gethook
-.Nd returns the current hook function
+.Nd returns the current hook function, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft lua_Hook

--- a/man3/lua_gethookcount.3
+++ b/man3/lua_gethookcount.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_gethookcount
-.Nd returns the current hook count
+.Nd returns the current hook count, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_gethookmask.3
+++ b/man3/lua_gethookmask.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_gethookmask
-.Nd returns the current hook mask
+.Nd returns the current hook mask, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_getinfo.3
+++ b/man3/lua_getinfo.3
@@ -3,7 +3,11 @@
 .Os
 .Sh NAME
 .Nm lua_getinfo
-.Nd returns information about a specific function or function invocation
+.Nd returns information about a specific function or function invocation, function indicator
+.Bo - Pq 0|1 ,
++ Pq 0|1|2 ,
+m
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_getlocal.3
+++ b/man3/lua_getlocal.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm lua_getlocal
-.Nd gets information about a local variable of a given activation record
+.Nd gets information about a local variable of a given activation record, function indicator
+.Bo -0, + Pq 0|1 ,
+-
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft const char *

--- a/man3/lua_getmetatable.3
+++ b/man3/lua_getmetatable.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm lua_getmetatable
-.Nd pushes onto the stack the metatable of the value at the given acceptable index
+.Nd pushes onto the stack the metatable of the value at the given acceptable index, function indicator
+.Bo -0, + Pq 0|1 ,
+-
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_getstack.3
+++ b/man3/lua_getstack.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_getstack
-.Nd get information about the interpreter runtime stack
+.Nd get information about the interpreter runtime stack, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_gettable.3
+++ b/man3/lua_gettable.3
@@ -4,7 +4,8 @@
 .Sh NAME
 .Nm lua_gettable
 .Nd pushes onto the stack the value t[k], where t is the value at the given valid
-index and k is the value at the top of the stack
+index and k is the value at the top of the stack, function indicator
+.Bq -1, +1, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_gettop.3
+++ b/man3/lua_gettop.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_gettop
-.Nd returns the index of the top element in the stack
+.Nd returns the index of the top element in the stack, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_getupvalue.3
+++ b/man3/lua_getupvalue.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm lua_getupvalue
-.Nd gets information about a closure's upvalue
+.Nd gets information about a closure's upvalue, function indicator
+.Bo -0, + Pq 0|1 ,
+-
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft const char *

--- a/man3/lua_insert.3
+++ b/man3/lua_insert.3
@@ -4,7 +4,8 @@
 .Sh NAME
 .Nm lua_insert
 .Nd moves the top element into the given valid index, shifting up the elements
-above this index to open space
+above this index to open space, function indicator
+.Bq -1, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_isboolean.3
+++ b/man3/lua_isboolean.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_isboolean
-.Nd check whether a value is a boolean
+.Nd check whether a value is a boolean, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_iscfunction.3
+++ b/man3/lua_iscfunction.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_iscfunction
-.Nd check whether a value is a C function
+.Nd check whether a value is a C function, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_isfunction.3
+++ b/man3/lua_isfunction.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_isfunction
-.Nd check whether a value is a function
+.Nd check whether a value is a function, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_islightuserdata.3
+++ b/man3/lua_islightuserdata.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_islightuserdata
-.Nd check whether a value is a light userdata
+.Nd check whether a value is a light userdata, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_isnil.3
+++ b/man3/lua_isnil.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_isnil
-.Nd check whether a value is a nil
+.Nd check whether a value is a nil, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_isnone.3
+++ b/man3/lua_isnone.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_isnone
-.Nd check whether a value is not valid
+.Nd check whether a value is not valid, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_isnoneornil.3
+++ b/man3/lua_isnoneornil.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_isnoneornil
-.Nd check whether a value is not valid or if the value is nil
+.Nd check whether a value is not valid or if the value is nil, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_isnumber.3
+++ b/man3/lua_isnumber.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_isnumber
-.Nd check whether a value is a number
+.Nd check whether a value is a number, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_isstring.3
+++ b/man3/lua_isstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_isstring
-.Nd check whether a value is a string or a number
+.Nd check whether a value is a string or a number, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_istable.3
+++ b/man3/lua_istable.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_istable
-.Nd check whether a value is a table
+.Nd check whether a value is a table, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_isthread.3
+++ b/man3/lua_isthread.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_isthread
-.Nd check whether a value is a thread
+.Nd check whether a value is a thread, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_isuserdata.3
+++ b/man3/lua_isuserdata.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_isuserdata
-.Nd check whether a value is a userdata
+.Nd check whether a value is a userdata, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_lessthan.3
+++ b/man3/lua_lessthan.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_lessthan
-.Nd compares two values
+.Nd compares two values, function indicator
+.Bq -0, +0, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_load.3
+++ b/man3/lua_load.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_load
-.Nd loads a Lua chunk
+.Nd loads a Lua chunk, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_newstate.3
+++ b/man3/lua_newstate.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_newstate
-.Nd creates a new, independent state
+.Nd creates a new, independent state, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft lua_State *

--- a/man3/lua_newtable.3
+++ b/man3/lua_newtable.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_newtable
-.Nd creates a new empty table and pushes it onto the stack
+.Nd creates a new empty table and pushes it onto the stack, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_newthread.3
+++ b/man3/lua_newthread.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_newthread
-.Nd creates a new thread
+.Nd creates a new thread, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft lua_State *

--- a/man3/lua_newuserdata.3
+++ b/man3/lua_newuserdata.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_newuserdata
-.Nd allocates a new block of memory with the given size
+.Nd allocates a new block of memory with the given size, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void *

--- a/man3/lua_next.3
+++ b/man3/lua_next.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm lua_next
-.Nd pops a key from the stack, and pushes a key-value pair from the table
+.Nd pops a key from the stack, and pushes a key-value pair from the table, function indicator
+.Bo -1, + Pq 2|0 ,
+e
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_objlen.3
+++ b/man3/lua_objlen.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_objlen
-.Nd returns the "length" of the value
+.Nd returns the "length" of the value, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft size_t

--- a/man3/lua_pcall.3
+++ b/man3/lua_pcall.3
@@ -3,7 +3,11 @@
 .Os
 .Sh NAME
 .Nm lua_pcall
-.Nd calls a function in protected mode
+.Nd calls a function in protected mode, function indicator
+.Bo - Pq nargs + 1 ,
++ Pq nresults|1 ,
+-
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_pop.3
+++ b/man3/lua_pop.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pop
-.Nd pops n elements from the stack
+.Nd pops n elements from the stack, function indicator
+.Bq -n, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushboolean.3
+++ b/man3/lua_pushboolean.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushboolean
-.Nd pushes a boolean value onto the stack
+.Nd pushes a boolean value onto the stack, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushcclosure.3
+++ b/man3/lua_pushcclosure.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushcclosure
-.Nd pushes a new C closure onto the stack
+.Nd pushes a new C closure onto the stack, function indicator
+.Bq -n, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushcfunction.3
+++ b/man3/lua_pushcfunction.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushcfunction
-.Nd pushes a C function onto the stack
+.Nd pushes a C function onto the stack, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushfstring.3
+++ b/man3/lua_pushfstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushfstring
-.Nd pushes onto the stack a formatted string and returns a pointer to this string
+.Nd pushes onto the stack a formatted string and returns a pointer to this string, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft const char *

--- a/man3/lua_pushinteger.3
+++ b/man3/lua_pushinteger.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushinteger
-.Nd pushes a number with value
+.Nd pushes a number with value, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushlightuserdata.3
+++ b/man3/lua_pushlightuserdata.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushlightuserdata
-.Nd pushes a light userdata onto the stack
+.Nd pushes a light userdata onto the stack, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushliteral.3
+++ b/man3/lua_pushliteral.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushliteral
-.Nd pushes the string onto the stack
+.Nd pushes the string onto the stack, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushlstring.3
+++ b/man3/lua_pushlstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushlstring
-.Nd pushes the string onto the stack
+.Nd pushes the string onto the stack, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushnil.3
+++ b/man3/lua_pushnil.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushnil
-.Nd pushes a nil value onto the stack
+.Nd pushes a nil value onto the stack, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushnumber.3
+++ b/man3/lua_pushnumber.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushnumber
-.Nd pushes a number onto the stack
+.Nd pushes a number onto the stack, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushstring.3
+++ b/man3/lua_pushstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushstring
-.Nd pushes the zero-terminated string onto the stack
+.Nd pushes the zero-terminated string onto the stack, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushthread.3
+++ b/man3/lua_pushthread.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushthread
-.Nd pushes the thread onto the stack
+.Nd pushes the thread onto the stack, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_pushvalue.3
+++ b/man3/lua_pushvalue.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushvalue
-.Nd pushes a copy of the element onto the stack
+.Nd pushes a copy of the element onto the stack, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_pushvfstring.3
+++ b/man3/lua_pushvfstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_pushvfstring
-.Nd pushes onto the stack a formatted string and returns a pointer to this string
+.Nd pushes onto the stack a formatted string and returns a pointer to this string, function indicator
+.Bq -0, +1, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft const char *

--- a/man3/lua_rawequal.3
+++ b/man3/lua_rawequal.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_rawequal
-.Nd compare two values for equality without calling metamethods
+.Nd compare two values for equality without calling metamethods, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_rawget.3
+++ b/man3/lua_rawget.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_rawget
-.Nd pops the key from the stack
+.Nd pops the key from the stack, function indicator
+.Bq -1, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_rawgeti.3
+++ b/man3/lua_rawgeti.3
@@ -4,7 +4,8 @@
 .Sh NAME
 .Nm lua_rawgeti
 .Nd pushes onto the stack the value t[n], where t is the value at the given
-valid index
+valid index, function indicator
+.Bq -0, +1, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_rawset.3
+++ b/man3/lua_rawset.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_rawset
-.Nd pops both the key and the value from the stack
+.Nd pops both the key and the value from the stack, function indicator
+.Bq -2, +0, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_rawseti.3
+++ b/man3/lua_rawseti.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_rawseti
-.Nd pops the value from the stack
+.Nd pops the value from the stack, function indicator
+.Bq -1, +0, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_register.3
+++ b/man3/lua_register.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_register
-.Nd sets the C function as the new value of global name
+.Nd sets the C function as the new value of global name, function indicator
+.Bq -0, +0, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_remove.3
+++ b/man3/lua_remove.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_remove
-.Nd removes the element at the given index
+.Nd removes the element at the given index, function indicator
+.Bq -1, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_replace.3
+++ b/man3/lua_replace.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_replace
-.Nd moves the top element into the given position
+.Nd moves the top element into the given position, function indicator
+.Bq -1, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_resume.3
+++ b/man3/lua_resume.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_resume
-.Nd starts and resumes a coroutine in a given thread
+.Nd starts and resumes a coroutine in a given thread, function indicator
+.Bq -?, +?, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_setallocf.3
+++ b/man3/lua_setallocf.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_setallocf
-.Nd changes the allocator function
+.Nd changes the allocator function, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_setfenv.3
+++ b/man3/lua_setfenv.3
@@ -3,7 +3,9 @@
 .Os
 .Sh NAME
 .Nm lua_setfenv
-.Nd pops a table from the stack and sets it as the new environment for the value
+.Nd pops a table from the stack and sets it as the new environment for the
+value, function indicator
+.Bq -1, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_setfield.3
+++ b/man3/lua_setfield.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_setfield
-.Nd pops the value from the stack
+.Nd pops the value from the stack, function indicator
+.Bq -1, +0, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_setglobal.3
+++ b/man3/lua_setglobal.3
@@ -3,7 +3,9 @@
 .Os
 .Sh NAME
 .Nm lua_setglobal
-.Nd pops a value from the stack and sets it as the new value of global name
+.Nd pops a value from the stack and sets it as the new value of global name,
+function indicator
+.Bq -1, +0, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_sethook.3
+++ b/man3/lua_sethook.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_sethook
-.Nd sets the debugging hook function
+.Nd sets the debugging hook function, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In fcntl.h
 .Ft int

--- a/man3/lua_setlocal.3
+++ b/man3/lua_setlocal.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm lua_setlocal
-.Nd sets the value of a local variable of a given activation record
+.Nd sets the value of a local variable of a given activation record, function indicator
+.Bo - Pq 0|1 ,
++0, -
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft const char *

--- a/man3/lua_setmetatable.3
+++ b/man3/lua_setmetatable.3
@@ -3,7 +3,9 @@
 .Os
 .Sh NAME
 .Nm lua_setmetatable
-.Nd pops a table from the stack and sets it as the new metatable for the value
+.Nd pops a table from the stack and sets it as the new metatable for the value,
+function indicator
+.Bq -1, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_settable.3
+++ b/man3/lua_settable.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_settable
-.Nd pops both the key and the value from the stack
+.Nd pops both the key and the value from the stack, function indicator
+.Bq -2, +0, e
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_settop.3
+++ b/man3/lua_settop.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_settop
-.Nd sets the stack top to the index
+.Nd sets the stack top to the index, function indicator
+.Bq -?, +?, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_setupvalue.3
+++ b/man3/lua_setupvalue.3
@@ -3,7 +3,10 @@
 .Os
 .Sh NAME
 .Nm lua_setupvalue
-.Nd sets the value of a closure's upvalue
+.Nd sets the value of a closure's upvalue, function indicator
+.Bo - Pq 0|1 ,
++0, -
+.Bc
 .Sh SYNOPSIS
 .In lua.h
 .Ft const char *

--- a/man3/lua_status.3
+++ b/man3/lua_status.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_status
-.Nd returns the status of the thread L
+.Nd returns the status of the thread L, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_toboolean.3
+++ b/man3/lua_toboolean.3
@@ -7,7 +7,8 @@
 .Sh SYNOPSIS
 .In lua.h
 .Ft int
-.Fn lua_toboolean "lua_State *L" "int index"
+.Fn lua_toboolean "lua_State *L" "int index", function indicator
+.Bq -0, +0, -
 .Sh DESCRIPTION
 .Fn lua_toboolean
 converts the Lua value at the given acceptable index to a C boolean value (0 or

--- a/man3/lua_tocfunction.3
+++ b/man3/lua_tocfunction.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_tocfunction
-.Nd converts a value to a C function
+.Nd converts a value to a C function, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft lua_CFunction

--- a/man3/lua_tointeger.3
+++ b/man3/lua_tointeger.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_tointeger
-.Nd converts the Lua value to the signed integral type
+.Nd converts the Lua value to the signed integral type, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft lua_Integer

--- a/man3/lua_tolstring.3
+++ b/man3/lua_tolstring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_tolstring
-.Nd converts the Lua value to a C string
+.Nd converts the Lua value to a C string, function indicator
+.Bq -0, +0, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft const char *

--- a/man3/lua_tonumber.3
+++ b/man3/lua_tonumber.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_tonumber
-.Nd converts the Lua value to the C type
+.Nd converts the Lua value to the C type, function indicator
+.Bq -0, +0, -
 .Xr lua_Number 3
 .Sh SYNOPSIS
 .In lua.h

--- a/man3/lua_topointer.3
+++ b/man3/lua_topointer.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_topointer
-.Nd converts the value to a generic C pointer
+.Nd converts the value to a generic C pointer, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft const void *

--- a/man3/lua_tostring.3
+++ b/man3/lua_tostring.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_tostring
-.Nd converts the Lua value to a C string
+.Nd converts the Lua value to a C string, function indicator
+.Bq -0, +0, m
 .Sh SYNOPSIS
 .In lua.h
 .Ft const char *

--- a/man3/lua_tothread.3
+++ b/man3/lua_tothread.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_tothread
-.Nd converts the value to a Lua thread
+.Nd converts the value to a Lua thread, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft lua_State *

--- a/man3/lua_touserdata.3
+++ b/man3/lua_touserdata.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_touserdata
-.Nd returns address to userdata
+.Nd returns address to userdata, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void *

--- a/man3/lua_type.3
+++ b/man3/lua_type.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_type
-.Nd returns the type of the value
+.Nd returns the type of the value, function indicator
+.Bq -0, +0, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int

--- a/man3/lua_typename.3
+++ b/man3/lua_typename.3
@@ -4,6 +4,9 @@
 .Sh NAME
 .Nm lua_typename
 .Nd returns the name of the type encoded by the value
+.Bd -literal -compact
+.Bq -0, +0, -
+.Ed
 .Sh SYNOPSIS
 .In lua.h
 .Ft const char *

--- a/man3/lua_xmove.3
+++ b/man3/lua_xmove.3
@@ -3,7 +3,9 @@
 .Os
 .Sh NAME
 .Nm lua_xmove
-.Nd exchange values between different threads of the same global state
+.Nd exchange values between different threads of the same global state,
+function indicator
+.Bq -?, +?, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft void

--- a/man3/lua_yield.3
+++ b/man3/lua_yield.3
@@ -3,7 +3,8 @@
 .Os
 .Sh NAME
 .Nm lua_yield
-.Nd yields a coroutine
+.Nd yields a coroutine, function indicator
+.Bq -?, +?, -
 .Sh SYNOPSIS
 .In lua.h
 .Ft int


### PR DESCRIPTION
The patch addes function's indicators to a short description.

Lua 5.1 Reference Manual in "3.7 – Functions and Types" [1] describes function's indicators and how to read this notation:

Each function has an indicator like this: `[-o, +p, x]`. The first field, `o`, is how many elements the function pops from the stack. The second field, `p`, is how many elements the function pushes onto the stack. (Any function always pushes its results after popping its arguments.) A field in the form `x|y` means the function can push (or pop) `x` or `y` elements, depending on the situation; an interrogation mark '?' means that we cannot know how many elements the function pops/pushes by looking only at its arguments (e.g., they may depend on what is on the stack). The third field, `x`, tells whether the function may throw errors: '-' means the function never throws any error; 'm' means the function may throw an error only due to not enough memory; 'e' means the function may throw other kinds of errors; 'v' means the function may throw an error on purpose.

1. http://www.lua.org/manual/5.1/manual.html#3.7